### PR TITLE
Feat: StatusTag 마크업 추가

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
   },
   plugins: ['react'],
   rules: {
-    'react/react-in-jsx-scope': 'off'
+    'react/react-in-jsx-scope': 'off',
+    'prettier/prettier': ['error', { endOfLine: 'auto' }]
   }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,5 +12,7 @@ module.exports = {
     sourceType: 'module'
   },
   plugins: ['react'],
-  rules: { 'react/react-in-jsx-scope': 'off' }
+  rules: {
+    'react/react-in-jsx-scope': 'off'
+  }
 };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { ThemeProvider } from '@emotion/react';
-import { StatusTag } from '@/components/StatusTag';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
 
-const theme = {
+const theme = createTheme({
   colors: {
     brand: '#2A2E56',
     normalWhite: '#ffffff',
@@ -21,14 +20,10 @@ const theme = {
     sighting: '#FF8F5E',
     protection: '#1E1AFF'
   }
-};
+});
 
 const App = function () {
-  return (
-    <ThemeProvider theme={theme}>
-      <StatusTag bgColor="#B91C1C"></StatusTag>
-    </ThemeProvider>
-  );
+  return <ThemeProvider theme={theme}></ThemeProvider>;
 };
 
 export default App;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,7 +26,7 @@ const theme = {
 const App = function () {
   return (
     <ThemeProvider theme={theme}>
-      <StatusTag status="missing" />
+      <StatusTag bgColor="#B91C1C"></StatusTag>
     </ThemeProvider>
   );
 };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ThemeProvider } from '@emotion/react';
+import { StatusTag } from '@/components/StatusTag';
 
 const theme = {
   colors: {
@@ -23,7 +24,11 @@ const theme = {
 };
 
 const App = function () {
-  return <ThemeProvider theme={theme}></ThemeProvider>;
+  return (
+    <ThemeProvider theme={theme}>
+      <StatusTag status="missing" />
+    </ThemeProvider>
+  );
 };
 
 export default App;

--- a/src/components/StatusTag/StatusTag.jsx
+++ b/src/components/StatusTag/StatusTag.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
+
+const StatusTag = ({ children, padding, backgroundColor, width, fontSize, borderRadius }) => {
+  return (
+    <Wrapper>
+      <StyledDiv
+        padding={padding}
+        backgroundColor={backgroundColor}
+        width={width}
+        fontSize={fontSize}
+        borderRadius={borderRadius}>
+        {children}
+      </StyledDiv>
+    </Wrapper>
+  );
+};
+
+const StyledDiv = styled.div`
+  background-color: ${({ backgroundColor }) => backgroundColor};
+  padding: ${({ padding }) => padding};
+  width: ${({ width }) => width};
+  text-align: center;
+  font-size: ${({ fontSize }) => fontSize};
+  border-radius: ${({ borderRadius }) => borderRadius};
+`;
+
+const Wrapper = styled.div``;
+
+StatusTag.defaultProps = {
+  children: '상태 없음',
+  padding: '0.6rem 0.6rem',
+  backgroundColor: '#ADADAD',
+  width: '5.6rem',
+  fontSize: '1.6rem',
+  borderRadius: '0 1.6rem 0 1.6rem'
+};
+
+StatusTag.propTypes = {
+  children: PropTypes.string,
+  padding: PropTypes.string,
+  backgroundColor: PropTypes.string,
+  width: PropTypes.string,
+  fontSize: PropTypes.string,
+  borderRadius: PropTypes.string
+};
+
+export default StatusTag;

--- a/src/components/StatusTag/StatusTag.jsx
+++ b/src/components/StatusTag/StatusTag.jsx
@@ -3,43 +3,53 @@ import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { STATUS } from '@/utils/constants';
 
-const StatusTag = ({ as, children, padding, color, bgColor, width, fontSize, borderRadius }) => {
+const StatusTag = ({
+  status,
+  children,
+  padding,
+  color,
+  bgColor,
+  width,
+  fontSize,
+  borderRadius
+}) => {
   return (
     <Wrapper>
       <StyledDiv
+        status={status}
         padding={padding}
         bgColor={bgColor}
         color={color}
         width={width}
         fontSize={fontSize}
         borderRadius={borderRadius}>
-        {decideText(as, bgColor, children)}
+        {decideText(status, bgColor, children)}
       </StyledDiv>
     </Wrapper>
   );
 };
 
-const decideColor = ({ as, bgColor, theme }) => {
+const decideColor = ({ status, bgColor, theme }) => {
   if (bgColor) {
     return bgColor;
   }
 
-  if (as) {
-    return theme.colors[STATUS[as]];
+  if (status) {
+    return theme.colors[status];
   }
 
   return theme.colors.lighterGray;
 };
 
-const decideText = (as, bgColor, children) => {
+const decideText = (status, bgColor, children) => {
   if (bgColor && children) {
     return children;
   }
 
   if ((bgColor && !children) || (!bgColor && children)) return '배경색과 텍스트 둘 다 입력해주세요';
 
-  if (as) {
-    return STATUS[as];
+  if (status) {
+    return STATUS[status];
   }
 
   return '내용을 입력해 주세요';
@@ -62,7 +72,7 @@ StatusTag.propTypes = {
   children: PropTypes.string,
   bgColor: PropTypes.string,
   color: PropTypes.string,
-  as: PropTypes.string,
+  status: PropTypes.string,
   padding: PropTypes.string,
   height: PropTypes.string,
   width: PropTypes.string,

--- a/src/components/StatusTag/StatusTag.jsx
+++ b/src/components/StatusTag/StatusTag.jsx
@@ -2,8 +2,14 @@ import React from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { STATUS } from '@/utils/constants';
+import { DEV_ERROR } from '@/utils/constants';
 
 const StatusTag = ({ status, children, padding, color, bgColor, fontSize, borderRadius }) => {
+  if (isWronglyUsed(status, bgColor, children)) {
+    console.error(DEV_ERROR.INVALID_PROP);
+    return;
+  }
+
   return (
     <Wrapper>
       <StyledSpan
@@ -13,11 +19,20 @@ const StatusTag = ({ status, children, padding, color, bgColor, fontSize, border
         color={color}
         fontSize={fontSize}
         borderRadius={borderRadius}>
-        {decideText(status, bgColor, children)}
+        {(status && STATUS[status]) || children}
       </StyledSpan>
     </Wrapper>
   );
 };
+
+const isWronglyUsed = (status, bgColor, children) => {
+  return (
+    doesExistOneOfThem(bgColor, children) || (!status && !doesExistBothOfThem(bgColor, children))
+  );
+};
+
+const doesExistOneOfThem = (a, b) => (!a && b) || (a && !b);
+const doesExistBothOfThem = (a, b) => a && b;
 
 const decideColor = ({ status, bgColor, theme }) => {
   if (bgColor) {
@@ -29,20 +44,6 @@ const decideColor = ({ status, bgColor, theme }) => {
   }
 
   return theme.colors.lighterGray;
-};
-
-const decideText = (status, bgColor, children) => {
-  if (bgColor && children) {
-    return children;
-  }
-
-  if ((bgColor && !children) || (!bgColor && children)) return '배경색과 텍스트 둘 다 입력해주세요';
-
-  if (status) {
-    return STATUS[status];
-  }
-
-  return '내용을 입력해 주세요';
 };
 
 const Wrapper = styled.div``;

--- a/src/components/StatusTag/StatusTag.jsx
+++ b/src/components/StatusTag/StatusTag.jsx
@@ -3,28 +3,18 @@ import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { STATUS } from '@/utils/constants';
 
-const StatusTag = ({
-  status,
-  children,
-  padding,
-  color,
-  bgColor,
-  width,
-  fontSize,
-  borderRadius
-}) => {
+const StatusTag = ({ status, children, padding, color, bgColor, fontSize, borderRadius }) => {
   return (
     <Wrapper>
-      <StyledDiv
+      <StyledSpan
         status={status}
         padding={padding}
         bgColor={bgColor}
         color={color}
-        width={width}
         fontSize={fontSize}
         borderRadius={borderRadius}>
         {decideText(status, bgColor, children)}
-      </StyledDiv>
+      </StyledSpan>
     </Wrapper>
   );
 };
@@ -57,10 +47,9 @@ const decideText = (status, bgColor, children) => {
 
 const Wrapper = styled.div``;
 
-const StyledDiv = styled.div`
+const StyledSpan = styled.span`
   background-color: ${(props) => decideColor(props)};
   padding: ${({ padding }) => padding || '0.6rem'};
-  width: ${({ width }) => width || '5.6rem'};
   border-radius: ${({ borderRadius }) => borderRadius || '0 1.6rem'};
   font-size: ${({ fontSize }) => fontSize || '1.6rem'};
   font-weight: bold;
@@ -74,8 +63,6 @@ StatusTag.propTypes = {
   color: PropTypes.string,
   status: PropTypes.string,
   padding: PropTypes.string,
-  height: PropTypes.string,
-  width: PropTypes.string,
   fontSize: PropTypes.string,
   borderRadius: PropTypes.string
 };

--- a/src/components/StatusTag/StatusTag.jsx
+++ b/src/components/StatusTag/StatusTag.jsx
@@ -1,46 +1,70 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
+import { STATUS } from '@/utils/constants';
 
-const StatusTag = ({ children, padding, backgroundColor, width, fontSize, borderRadius }) => {
+const StatusTag = ({ as, children, padding, color, bgColor, width, fontSize, borderRadius }) => {
   return (
     <Wrapper>
       <StyledDiv
         padding={padding}
-        backgroundColor={backgroundColor}
+        bgColor={bgColor}
+        color={color}
         width={width}
         fontSize={fontSize}
         borderRadius={borderRadius}>
-        {children}
+        {decideText(as, bgColor, children)}
       </StyledDiv>
     </Wrapper>
   );
 };
 
-const StyledDiv = styled.div`
-  background-color: ${({ backgroundColor }) => backgroundColor};
-  padding: ${({ padding }) => padding};
-  width: ${({ width }) => width};
-  text-align: center;
-  font-size: ${({ fontSize }) => fontSize};
-  border-radius: ${({ borderRadius }) => borderRadius};
-`;
+const decideColor = ({ as, bgColor, theme }) => {
+  if (bgColor) {
+    return bgColor;
+  }
+
+  if (as) {
+    return theme.colors[STATUS[as]];
+  }
+
+  return theme.colors.lighterGray;
+};
+
+const decideText = (as, bgColor, children) => {
+  if (bgColor && children) {
+    return children;
+  }
+
+  if ((bgColor && !children) || (!bgColor && children)) return '배경색과 텍스트 둘 다 입력해주세요';
+
+  if (as) {
+    return STATUS[as];
+  }
+
+  return '내용을 입력해 주세요';
+};
 
 const Wrapper = styled.div``;
 
-StatusTag.defaultProps = {
-  children: '상태 없음',
-  padding: '0.6rem 0.6rem',
-  backgroundColor: '#ADADAD',
-  width: '5.6rem',
-  fontSize: '1.6rem',
-  borderRadius: '0 1.6rem 0 1.6rem'
-};
+const StyledDiv = styled.div`
+  background-color: ${(props) => decideColor(props)};
+  padding: ${({ padding }) => padding || '0.6rem'};
+  width: ${({ width }) => width || '5.6rem'};
+  border-radius: ${({ borderRadius }) => borderRadius || '0 1.6rem'};
+  font-size: ${({ fontSize }) => fontSize || '1.6rem'};
+  font-weight: bold;
+  text-align: center;
+  color: ${({ color, theme }) => color || theme.colors.normalWhite};
+`;
 
 StatusTag.propTypes = {
   children: PropTypes.string,
+  bgColor: PropTypes.string,
+  color: PropTypes.string,
+  as: PropTypes.string,
   padding: PropTypes.string,
-  backgroundColor: PropTypes.string,
+  height: PropTypes.string,
   width: PropTypes.string,
   fontSize: PropTypes.string,
   borderRadius: PropTypes.string

--- a/src/components/StatusTag/StatusTag.jsx
+++ b/src/components/StatusTag/StatusTag.jsx
@@ -13,37 +13,16 @@ const StatusTag = ({ status, children, padding, color, bgColor, fontSize, border
   return (
     <Wrapper>
       <StyledSpan
-        status={status}
         padding={padding}
+        status={status}
         bgColor={bgColor}
         color={color}
         fontSize={fontSize}
         borderRadius={borderRadius}>
-        {(status && STATUS[status]) || children}
+        {STATUS[status] || children}
       </StyledSpan>
     </Wrapper>
   );
-};
-
-const isWronglyUsed = (status, bgColor, children) => {
-  return (
-    doesExistOneOfThem(bgColor, children) || (!status && !doesExistBothOfThem(bgColor, children))
-  );
-};
-
-const doesExistOneOfThem = (a, b) => (!a && b) || (a && !b);
-const doesExistBothOfThem = (a, b) => a && b;
-
-const decideColor = ({ status, bgColor, theme }) => {
-  if (bgColor) {
-    return bgColor;
-  }
-
-  if (status) {
-    return theme.colors[status];
-  }
-
-  return theme.colors.lighterGray;
 };
 
 const Wrapper = styled.div``;
@@ -69,3 +48,26 @@ StatusTag.propTypes = {
 };
 
 export default StatusTag;
+
+const isWronglyUsed = (status, bgColor, children) => {
+  return (
+    (status && (XOR(bgColor, children) || AND(bgColor, children))) ||
+    (!status && (XOR(bgColor, children) || NAND(bgColor, children)))
+  );
+};
+
+const XOR = (a, b) => (!a && b) || (a && !b);
+const AND = (a, b) => a && b;
+const NAND = (a, b) => !(a && b);
+
+const decideColor = ({ status, bgColor, theme }) => {
+  if (bgColor) {
+    return bgColor;
+  }
+
+  if (status) {
+    return theme.colors[status];
+  }
+
+  return theme.colors.lighterGray;
+};

--- a/src/components/StatusTag/index.js
+++ b/src/components/StatusTag/index.js
@@ -1,0 +1,1 @@
+export { default as StatusTag } from './StatusTag';

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,1 +1,7 @@
 export const AUTH_ALERT = {};
+export const STATUS = Object.freeze({
+  missing: '실종',
+  completion: '완료',
+  sighting: '목격',
+  protection: '보호'
+});

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -3,10 +3,3 @@ export const AUTH_ALERT = {};
 export const DEV_ERROR = Object.freeze({
   INVALID_PROP: '잘못된 Prop이 입력되었습니다.'
 });
-
-export const STATUS = Object.freeze({
-  missing: '실종',
-  completion: '완료',
-  sighting: '목격',
-  protection: '보호'
-});

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,4 +1,9 @@
 export const AUTH_ALERT = {};
+
+export const DEV_ERROR = Object.freeze({
+  INVALID_PROP: '잘못된 Prop이 입력되었습니다.'
+});
+
 export const STATUS = Object.freeze({
   missing: '실종',
   completion: '완료',


### PR DESCRIPTION
## 이슈 번호 <!-- 관련된 이슈의 번호를 # 뒤에 입력해주세요  -->

- close: #3 

## 특이 사항

### 컴포넌트 추상화 정도에 대해서

- 라벨은 공통된 내용이 여러 곳에서 사용될 것으로 예상되므로, as prop에 미리 정의된 키워드를 입력하면 styled 내부에서 알아서 분기시켜주는 방향으로 구현.
- bgColor와 children도 받을 수 있으나, 둘 중 하나만 입력하는 경우에는 "텍스트와 bgColor를 동시에 입력해주세요" 문구를 렌더링함으로써 사실상 사용 불가능하도록 만듬