### PR TITLE
Feat: SelectionBox 마크업 추가

### DIFF
--- a/src/components/SelectionBox/SelectionBox.jsx
+++ b/src/components/SelectionBox/SelectionBox.jsx
@@ -59,7 +59,6 @@ const Selection = styled.select`
   background: transparent;
   border: 0 none;
   outline: 0 none;
-  z-index: 3;
   font-size: ${({ fontSize }) => fontSize || '1.6rem'};
   color: ${({ color }) => color};
   font-weight: bold;
@@ -74,7 +73,6 @@ const Arrow = styled(KeyboardArrowDownIcon)`
   position: absolute;
   top: -0.1rem;
   right: 0;
-  z-index: 1;
   width: 2rem;
   height: inherit;
 `;

--- a/src/components/SelectionBox/SelectionBox.jsx
+++ b/src/components/SelectionBox/SelectionBox.jsx
@@ -57,8 +57,8 @@ const Selection = styled.select`
   height: 100%;
   padding-right: 2.5rem;
   background: transparent;
-  border: 0 none;
-  outline: 0 none;
+  border: 0;
+  outline: 0;
   font-size: ${({ fontSize }) => fontSize || '1.6rem'};
   color: ${({ color }) => color};
   font-weight: bold;

--- a/src/components/SelectionBox/SelectionBox.jsx
+++ b/src/components/SelectionBox/SelectionBox.jsx
@@ -53,13 +53,6 @@ const Wrapper = styled.div`
 `;
 
 const Selection = styled.select`
-  -o-appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  ::-ms-expand {
-    display: none;
-  }
-  appearance: none;
   width: 100%;
   height: 100%;
   padding-right: 2.5rem;

--- a/src/components/SelectionBox/SelectionBox.jsx
+++ b/src/components/SelectionBox/SelectionBox.jsx
@@ -21,21 +21,19 @@ const SelectionBox = ({ options, defaultOption, required, disabled, fontSize, he
   };
 
   return (
-    <Wrapper>
-      <SelectionWrapper color={color}>
-        <Selection
-          onChange={changeHandler}
-          disabled={disabled}
-          color={color}
-          fontSize={fontSize}
-          height={height}>
-          <Option>{defaultOption}</Option>
-          {options.map((option) => (
-            <Option key={option.id}>{option.text}</Option>
-          ))}
-        </Selection>
-        <Arrow color={color} />
-      </SelectionWrapper>
+    <Wrapper color={color}>
+      <Selection
+        onChange={changeHandler}
+        disabled={disabled}
+        color={color}
+        fontSize={fontSize}
+        height={height}>
+        <Option>{defaultOption}</Option>
+        {options.map((option) => (
+          <Option key={option.id}>{option.text}</Option>
+        ))}
+      </Selection>
+      <Arrow color={color} />
     </Wrapper>
   );
 };
@@ -47,9 +45,7 @@ const decideColor = ({ chosen, disabled, required }) => {
   return COLOR_SET.brand;
 };
 
-const Wrapper = styled.div``;
-
-const SelectionWrapper = styled.div`
+const Wrapper = styled.div`
   display: inline-block;
   position: relative;
   height: ${({ height }) => height || '2.4rem'};

--- a/src/components/SelectionBox/SelectionBox.jsx
+++ b/src/components/SelectionBox/SelectionBox.jsx
@@ -30,8 +30,8 @@ const SelectionBox = ({ options, defaultOption, required, disabled, fontSize, he
           fontSize={fontSize}
           height={height}>
           <Option>{defaultOption}</Option>
-          {options.map((content, index) => (
-            <Option key={index}>{content}</Option>
+          {options.map((option) => (
+            <Option key={option.id}>{option.text}</Option>
           ))}
         </Selection>
         <Arrow color={color} />

--- a/src/components/SelectionBox/SelectionBox.jsx
+++ b/src/components/SelectionBox/SelectionBox.jsx
@@ -84,7 +84,6 @@ SelectionBox.propTypes = {
   defaultOption: PropTypes.string.isRequired,
   fontSize: PropTypes.string,
   height: PropTypes.string,
-  theme: PropTypes.node,
   disabled: PropTypes.bool,
   required: PropTypes.bool
 };

--- a/src/components/SelectionBox/SelectionBox.jsx
+++ b/src/components/SelectionBox/SelectionBox.jsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+
+const COLOR_SET = Object.freeze({
+  normalPink: '#FF8585',
+  normalGreen: '#3BAB29',
+  normalBlack: '#2F3438',
+  disabled: '#aaaaaa',
+  brand: '#2A2E56'
+});
+
+const SelectionBox = ({ options, defaultOption, required, disabled, fontSize, height }) => {
+  const [color, setColor] = useState(decideColor({ required, disabled }));
+
+  const changeHandler = (e) => {
+    const chosen = e.target.selectedIndex !== 0;
+    const nextColor = decideColor({ required, chosen, disabled });
+    setColor(nextColor);
+  };
+
+  return (
+    <Wrapper>
+      <SelectionWrapper color={color}>
+        <Selection
+          onChange={changeHandler}
+          disabled={disabled}
+          color={color}
+          fontSize={fontSize}
+          height={height}>
+          <Option>{defaultOption}</Option>
+          {options.map((content, index) => (
+            <Option key={index}>{content}</Option>
+          ))}
+        </Selection>
+        <Arrow color={color} />
+      </SelectionWrapper>
+    </Wrapper>
+  );
+};
+
+const decideColor = ({ chosen, disabled, required }) => {
+  if (disabled) return COLOR_SET.disabled;
+  if (chosen) return COLOR_SET.normalGreen;
+  if (required) return COLOR_SET.normalPink;
+  return COLOR_SET.brand;
+};
+
+const Wrapper = styled.div``;
+
+const SelectionWrapper = styled.div`
+  display: inline-block;
+  position: relative;
+  height: ${({ height }) => height || '2.4rem'};
+  border-bottom: ${({ color }) => `0.15rem solid ${color}`};
+`;
+
+const Selection = styled.select`
+  -o-appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  ::-ms-expand {
+    display: none;
+  }
+  appearance: none;
+  width: 100%;
+  height: 100%;
+  padding-right: 2.5rem;
+  background: transparent;
+  border: 0 none;
+  outline: 0 none;
+  z-index: 3;
+  font-size: ${({ fontSize }) => fontSize || '1.6rem'};
+  color: ${({ color }) => color};
+  font-weight: bold;
+`;
+
+const Option = styled.option`
+  color: ${COLOR_SET.normalBlack};
+`;
+
+const Arrow = styled(KeyboardArrowDownIcon)`
+  color: ${({ color }) => color};
+  position: absolute;
+  top: -0.1rem;
+  right: 0;
+  z-index: 1;
+  width: 2rem;
+  height: inherit;
+`;
+
+SelectionBox.propTypes = {
+  options: PropTypes.array.isRequired,
+  defaultOption: PropTypes.string.isRequired,
+  fontSize: PropTypes.string,
+  height: PropTypes.string,
+  theme: PropTypes.node,
+  disabled: PropTypes.bool,
+  required: PropTypes.bool
+};
+
+export default SelectionBox;

--- a/src/components/SelectionBox/index.js
+++ b/src/components/SelectionBox/index.js
@@ -1,0 +1,1 @@
+export { default as SelectionBox } from './SelectionBox';

--- a/src/index.css
+++ b/src/index.css
@@ -46,3 +46,14 @@ button {
   cursor: pointer;
   outline: 0;
 }
+
+select {
+  -o-appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+select::-ms-expand {
+  display: none;
+}


### PR DESCRIPTION
## 이슈 번호 <!-- 관련된 이슈의 번호를 # 뒤에 입력해주세요  -->

- close: #7 

## 특이 사항

### 컴포넌트 방향성에 관해서
- size prop으로 크기 분기가 요구되는 컴포넌트임 (small, large등)
- 모바일 사이즈 기준(small)으로 컴포넌트 제작함. 데스크탑에선 large 필요
- 필요한 경우, 본 컴포넌트 사이즈 변경 가능
    - 사이즈 변경 prop은 height, fontSize 이며, 추후 페이지 제작시 small 사이즈 조절이 필요하다면 협의 후 수정 필요
- 마크업이므로 구체적인 로직은 제외함.
    - 임시로 required, disabled등을 prop으로 받아서 색상을 분기시켜 놓음

### 코드 구성에 관해서
- 컴포넌트 내에서 사용되는 컬러들은 객체 동결, 객체 리터럴 네임 스페이싱, 상단 배치
    - 확장되거나 수정될 필요가 없고, 수정되는 경우 문제로 이어질 수 있음
    - 색상을 통합 관리하기 위해 네임 스페이싱 사용
   
- label과 같이 사용하지 않으므로 select 태그에 id는 사용하지 않음 (로직 구성시 변경 가능성 존재)
- form 태그를 이용해서 서버에 전달하는 것이 아니므로, option 태그의 value 속성은 기재하지 않음.

### 기타
- Arrow를 눌렀을 때 select 태그를 강제로 drop down하는 방법이 존재하지 않음.
- mui 라이브러리 사용을 고려하였으나, 사용법이 까다롭다고 판단
- 시간 관계상, 추후 라이브러리 사용법을 익히고 도입 여부 검토 후, 도입 가능하다고 판단되면 리펙토링 하는 방향으로 설정